### PR TITLE
fix: correct type on transaction type

### DIFF
--- a/types/shippo/index.d.ts
+++ b/types/shippo/index.d.ts
@@ -653,7 +653,7 @@ declare namespace Shippo {
     interface Transaction extends Metadata {
         object_state: ObjectState;
         status: Transaction.Status;
-        rate: Rate;
+        rate: string;
         metadata: string;
         label_file_type: LabelFileType;
         test: boolean;

--- a/types/shippo/shippo-tests.ts
+++ b/types/shippo/shippo-tests.ts
@@ -106,6 +106,46 @@ shippo.transaction.create({
 });
 
 // $ExpectType Promise<Transaction>
+shippo.transaction.create({
+    carrier_account: "carrier_account",
+    label_file_type: "PDF",
+    metadata: 'metadata',
+    servicelevel_token: "servicelevel_token",
+    shipment: {
+        address_to: {
+            name: "Mr Hippo",
+            street1: "965 Mission St #572",
+            city: "San Francisco",
+            state: "CA",
+            zip: "94103",
+            country: "US",
+            phone: "4151234567",
+            email: "mrhippo@goshippo.com",
+        },
+        address_from: {
+            name: "Mrs Hippo",
+            street1: "1092 Indian Summer Ct",
+            city: "San Jose",
+            state: "CA",
+            zip: "95122",
+            country: "US",
+            phone: "4159876543",
+            email: "mrshippo@goshippo.com",
+        },
+        parcels: [
+            {
+                distance_unit: "yd",
+                height: "1",
+                length: "1",
+                mass_unit: "kg",
+                weight: "1",
+                width: "1",
+            },
+        ],
+     }
+});
+
+// $ExpectType Promise<Transaction>
 shippo.transaction.retrieve("transaction_id");
 
 // $ExpectType Promise<PaginatedList<Transaction>>


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.goshippo.com/shippoapi/public-api/#operation/CreateTransaction>


